### PR TITLE
Tweak: Load admin CSS using wp_enqueue_style only on the floating cart setting page.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: cart, woocommerce, woocommerce cart, floating cart, side cart, woo cart, w
 Requires at least: 5.9 or higher
 Requires PHP: 7.4
 Tested up to: 6.2
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,10 @@ Floating cart button and sidebar shopping cart will not be visible on cart and c
 
 
 == Changelog ==
+
+= 1.1.2 - ?, 2023 = 
+
+- Tweak: Load admin CSS using wp_enqueue_style only on the floating cart setting page.
 
 = 1.1.1 - 20 April, 2023 = 
 

--- a/addonify-floating-cart.php
+++ b/addonify-floating-cart.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Addonify Floating Cart For WooCommerce
  * Plugin URI:        https://addonify.com/addonify-floating-cart
  * Description:       Addonify Floating Cart is a free WooCommerce addon that adds an interactive sticky shopping cart on your website allowing your visitors no need to go to cart page to manage their cart items.
- * Version:           1.1.1
+ * Version:           1.1.2
  * Requires at least: 5.9 or higher
  * Requires PHP:      7.4
  * Author:            Addonify
@@ -31,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'ADDONIFY_FLOATING_CART_VERSION', '1.1.1' );
+define( 'ADDONIFY_FLOATING_CART_VERSION', '1.1.2' );
 define( 'ADDONIFY_FLOATING_CART_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ADDONIFY_FLOATING_CART_DB_INITIALS', 'addonify_fc_' );
 

--- a/admin/class-addonify-floating-cart-admin.php
+++ b/admin/class-addonify-floating-cart-admin.php
@@ -96,7 +96,10 @@ class Addonify_Floating_Cart_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'assets/css/admin.css', array(), $this->version, 'all' );
+		if ( isset( $_GET['page'] ) && $_GET['page'] == $this->settings_page_slug ) { // phpcs:ignore
+
+			wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'assets/css/admin.css', array(), $this->version, 'all' );
+		}	
 	}
 
 	/**


### PR DESCRIPTION
- Tweak: Load admin CSS using wp_enqueue_style only on the floating cart setting page.