### PR TITLE
Fix: Plugins settings page link, plugins loaded after WooCommerce, re…

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -119,11 +119,11 @@ Floating cart button and sidebar shopping cart will not be visible on cart and c
 
 - New: Brand new plugin setting page design.
 - Added: Option to open cart modal on trigger button hover.
-- Added: Option to enable floating cart on cart page.
-- Added: Option to enable floating cart on checkout page.
 - Added: Plugin setting page notification messages.
+- Fix: Plugin setting page link in plugins listing page is displayed before `Deactivate` link.
 - Fix: Documentation link in plugin setting page header section.
-- Improvement: Plugin setting page vue js code.
+- Improvement: Used `plugins_loaded`hook to run the plugin.
+- Improvement: Plugin setting page vue js code
 - Improvement: Plugin setting page SCSS.
 - Improvement: Plugin setting page REST API options.
 - Improvement: Number input control (Vue JS).

--- a/addonify-floating-cart.php
+++ b/addonify-floating-cart.php
@@ -32,6 +32,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Rename this for your plugin and update it as you release new versions.
  */
 define( 'ADDONIFY_FLOATING_CART_VERSION', '1.2.0' );
+define( 'ADDONIFY_FLOATING_CART_BASENAME', plugin_basename( __FILE__ ) );
 define( 'ADDONIFY_FLOATING_CART_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ADDONIFY_FLOATING_CART_DB_INITIALS', 'addonify_fc_' );
 
@@ -75,8 +76,22 @@ require plugin_dir_path( __FILE__ ) . 'includes/template-functions.php';
  */
 function run_addonify_floating_cart() {
 
-	$plugin = new Addonify_Floating_Cart();
-	$plugin->run();
+	if ( class_exists( 'WooCommerce' ) ) {
+
+		$plugin = new Addonify_Floating_Cart();
+		$plugin->run();
+	} else {
+		add_action(
+			'admin_notices',
+			function() {
+				?>
+				<div class="notice notice-error is-dismissible">
+					<p><?php echo esc_html__( 'Addonify Floating Cart requires WooCommerce in order to work.', 'addonify-floating-cart' ); ?></p>
+				</div>
+				<?php
+			}
+		);
+	}
 
 }
-run_addonify_floating_cart();
+add_action( 'plugins_loaded', 'run_addonify_floating_cart', 50 );

--- a/admin/class-addonify-floating-cart-admin.php
+++ b/admin/class-addonify-floating-cart-admin.php
@@ -52,29 +52,13 @@ class Addonify_Floating_Cart_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @param      string    $plugin_name       The name of this plugin.
-	 * @param      string    $version    The version of this plugin.
+	 * @param string $plugin_name The name of this plugin.
+	 * @param string $version     The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
 
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
-	}
-
-
-	public function admin_init() {
-
-		if ( ! class_exists( 'WooCommerce' ) ) {
-
-			add_action( 'admin_notices', array( $this, 'woocommerce_not_active_notice' ) ); 
-		}
-
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_styles' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'add_menu_callback' ], 20 );
-
-		// Add a custom link in plugins.php page in wp-admin.
-		add_action( 'plugin_action_links', array( $this, 'custom_plugin_link_callback' ), 10, 2 );
+		$this->version     = $version;
 	}
 
 	/**
@@ -86,8 +70,14 @@ class Addonify_Floating_Cart_Admin {
 
 		if ( isset( $_GET['page'] ) && $_GET['page'] == $this->settings_page_slug ) { // phpcs:ignore
 
-			wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'assets/css/admin.css', array(), $this->version, 'all' );
-		}	
+			wp_enqueue_style(
+				$this->plugin_name,
+				plugin_dir_url( __FILE__ ) . 'assets/css/admin.css',
+				array(),
+				$this->version,
+				'all'
+			);
+		}
 	}
 
 	/**
@@ -97,93 +87,94 @@ class Addonify_Floating_Cart_Admin {
 	 */
 	public function enqueue_scripts() {
 
-		wp_register_script( 
-			"{$this->plugin_name}-manifest", 
-			plugin_dir_url( __FILE__ ) . 'assets/js/manifest.js', 
-			null, 
-			$this->version, 
-			true 
+		wp_register_script(
+			"{$this->plugin_name}-manifest",
+			plugin_dir_url( __FILE__ ) . 'assets/js/manifest.js',
+			null,
+			$this->version,
+			true
 		);
 
-		wp_register_script( 
-			"{$this->plugin_name}-vendor", 
-			plugin_dir_url( __FILE__ ) . 'assets/js/vendor.js', 
-			array(  "{$this->plugin_name}-manifest" ), 
-			$this->version, 
-			true 
+		wp_register_script(
+			"{$this->plugin_name}-vendor",
+			plugin_dir_url( __FILE__ ) . 'assets/js/vendor.js',
+			array( "{$this->plugin_name}-manifest" ),
+			$this->version,
+			true
 		);
 
-		wp_register_script( 
-			"{$this->plugin_name}-main", 
-			plugin_dir_url( __FILE__ ) . 'assets/js/main.js', 
-			array( 'lodash', "{$this->plugin_name}-vendor", 'wp-i18n', 'wp-api-fetch' ), 
-			$this->version, 
-			true 
+		wp_register_script(
+			"{$this->plugin_name}-main",
+			plugin_dir_url( __FILE__ ) . 'assets/js/main.js',
+			array( 'lodash', "{$this->plugin_name}-vendor", 'wp-i18n', 'wp-api-fetch' ),
+			$this->version,
+			true
 		);
 
-		if( 
-			isset( $_GET['page'] ) && 
-			$_GET['page'] == $this->settings_page_slug 
-		) {
+		if ( isset( $_GET['page'] ) && $_GET['page'] == $this->settings_page_slug ) { // phpcs:ignore
 			wp_enqueue_script( "{$this->plugin_name}-manifest" );
 
 			wp_enqueue_script( "{$this->plugin_name}-vendor" );
 
 			wp_enqueue_script( "{$this->plugin_name}-main" );
 
-			wp_localize_script( "{$this->plugin_name}-main", 'ADDONIFY_WOOFC_LOCOLIZER', array(
-				'admin_url'  						=> esc_url( admin_url( '/' ) ),
-				'ajax_url'   						=> esc_url( admin_url( 'admin-ajax.php' ) ),
-				'rest_namespace' 					=> 'addonify_floating_cart_options_api',
-				'version_number' 					=> $this->version,
-			));
+			wp_localize_script(
+				"{$this->plugin_name}-main",
+				'ADDONIFY_WOOFC_LOCOLIZER',
+				array(
+					'admin_url'      => esc_url( admin_url( '/' ) ),
+					'ajax_url'       => esc_url( admin_url( 'admin-ajax.php' ) ),
+					'rest_namespace' => 'addonify_floating_cart_options_api',
+					'version_number' => $this->version,
+				)
+			);
 		}
 
 		wp_set_script_translations( "{$this->plugin_name}-main", $this->plugin_name );
 	}
 
-	public function add_menu_callback(){
-
-		// do not show menu if woocommerce is not active
-		if ( ! class_exists( 'WooCommerce' ) )  {
-			return;
-		} 
+	/**
+	 * Callback function to register admin menu.
+	 *
+	 * @since    1.0.0
+	 */
+	public function add_menu_callback() {
 
 		global $admin_page_hooks;
-		
-		$parent_menu_slug = array_search( 'addonify', (array)$admin_page_hooks, true );
+
+		$parent_menu_slug = array_search( 'addonify', (array) $admin_page_hooks, true );
 
 		if ( ! $parent_menu_slug ) {
 
-			add_menu_page( 
-				'Addonify Settings', 
-				'Addonify', 
-				'manage_options', 
-				$this->settings_page_slug, 
-				array( $this, 'get_settings_screen_contents' ), 
-				'dashicons-superhero', 
-				70 
+			add_menu_page(
+				'Addonify Settings',
+				'Addonify',
+				'manage_options',
+				$this->settings_page_slug,
+				array( $this, 'get_settings_screen_contents' ),
+				'dashicons-superhero',
+				70
 			);
 
-			add_submenu_page(  
-				$this->settings_page_slug, 
-				'Addonify Floating Cart Settings', 
-				'Floating Cart', 
-				'manage_options', 
-				$this->settings_page_slug, 
-				array( $this, 'get_settings_screen_contents' ), 
-				0 
+			add_submenu_page(
+				$this->settings_page_slug,
+				'Addonify Floating Cart Settings',
+				'Floating Cart',
+				'manage_options',
+				$this->settings_page_slug,
+				array( $this, 'get_settings_screen_contents' ),
+				0
 			);
 		} else {
 
-			add_submenu_page(  
-				$parent_menu_slug, 
-				'Addonify Floating Cart Settings', 
-				'Floating Cart', 
-				'manage_options', 
-				$this->settings_page_slug, 
-				array( $this, 'get_settings_screen_contents' ), 
-				0 
+			add_submenu_page(
+				$parent_menu_slug,
+				'Addonify Floating Cart Settings',
+				'Floating Cart',
+				'manage_options',
+				$this->settings_page_slug,
+				array( $this, 'get_settings_screen_contents' ),
+				0
 			);
 		}
 	}
@@ -193,32 +184,25 @@ class Addonify_Floating_Cart_Admin {
 	 *
 	 * @since    1.0.0
 	 * @param    string $links Links.
-	 * @param    string $file  PLugin file name.
 	 */
-	public function custom_plugin_link_callback( $links, $file ) {
+	public function custom_plugin_link_callback( $links ) {
 
-		if ( plugin_basename( dirname( __FILE__, 2 ) . '/addonify-floating-cart.php' ) === $file ) {
+		// add "Settings" link.
+		$action_links = array(
+			'<a href="admin.php?page=' . esc_attr( $this->settings_page_slug ) . '">' . __( 'Settings', 'addonify-floating-cart' ) . '</a>',
+		);
 
-			// add "Settings" link.
-			$links[] = '<a href="admin.php?page=' . esc_attr( $this->settings_page_slug ) . '">' . __( 'Settings', 'addonify-floating-cart' ) . '</a>';
-		}
-
-		return $links;
+		return array_merge( $action_links, $links );
 	}
 
-	// callback function
-	// get contents for settings page screen
+	/**
+	 * Callback function to register admin menu page.
+	 *
+	 * @since    1.0.0
+	 */
 	public function get_settings_screen_contents() {
 		?>
 		<div id="___adfy-floatingcart-app___"></div>
-		<?php
-	}
-
-	public function woocommerce_not_active_notice() {
-		?>
-		<div class="notice notice-error is-dismissible">
-			<p><?php echo __( 'Addonify Floating Cart requires WooCommerce in order to work.', 'addonify-floating-cart' ); ?></p>
-		</div>
 		<?php
 	}
 }

--- a/includes/class-addonify-floating-cart.php
+++ b/includes/class-addonify-floating-cart.php
@@ -164,7 +164,13 @@ class Addonify_Floating_Cart {
 
 		$plugin_admin = new Addonify_Floating_Cart_Admin( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_admin, 'admin_init' );
+		$this->loader->add_filter( 'plugin_action_links_' . ADDONIFY_FLOATING_CART_BASENAME, $plugin_admin, 'custom_plugin_link_callback' );
+
+		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_menu_callback', 20 );
+
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 	}
 
 	/**
@@ -178,7 +184,7 @@ class Addonify_Floating_Cart {
 
 		$plugin_public = new Addonify_Floating_Cart_Public( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_public, 'init' );
+		$this->loader->add_action( 'init', $plugin_public, 'init' );
 	}
 
 	/**
@@ -235,5 +241,4 @@ class Addonify_Floating_Cart {
 
 		$plugin_rest = new Addonify_Floating_Cart_Rest_Api();
 	}
-
 }

--- a/includes/functions/fields/cart.php
+++ b/includes/functions/fields/cart.php
@@ -25,20 +25,6 @@ function addonify_floating_cart_cart_options_settings() {
 			'badge' 		=> __( 'Required', 'addonify-floating-cart' ),
 			'value' 		=> addonify_floating_cart_get_option( 'enable_floating_cart' ),
 		),
-		'enable_floating_cart_on_cart_page' => array(
-			'label' 		=> __( 'Enable on WooCommerce cart page', 'addonify-floating-cart' ),
-			'type'  		=> 'switch',
-			'description' 	=> __( 'By default, floating cart is disabled in cart page.', 'addonify-floating-cart' ),
-			'dependent' 	=> array( 'enable_floating_cart' ),
-			'value' 		=> addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ),
-		),
-		'enable_floating_cart_on_checkout_page' => array(
-			'label' 		=> __( 'Enable on WooCommerce checkout page', 'addonify-floating-cart' ),
-			'type'  		=> 'switch',
-			'description' 	=> __( 'By default, floating cart is disabled in checkout page.', 'addonify-floating-cart' ),
-			'dependent' 	=> array( 'enable_floating_cart' ),
-			'value' 		=> addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ),
-		),
 		'open_cart_modal_immediately_after_add_to_cart' => array(
 			'label'     	=> __( 'Open cart modal on add to cart button click', 'addonify-floating-cart' ),
 			'type'      	=> 'switch',

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -47,8 +47,6 @@ function addonify_floating_cart_settings_fields_defaults() {
 		array(
 			// Main cart settings options.
 			'enable_floating_cart'                         => true,
-			'enable_floating_cart_on_cart_page'            => false,
-			'enable_floating_cart_on_checkout_page'        => false,
 			'open_cart_modal_immediately_after_add_to_cart' => true,
 			'open_cart_modal_after_click_on_view_cart'     => false,
 			'enable_shopping_meter'                        => false,

--- a/public/class-addonify-floating-cart-public.php
+++ b/public/class-addonify-floating-cart-public.php
@@ -57,10 +57,7 @@ class Addonify_Floating_Cart_Public {
 	 */
 	public function init() {
 
-		if (
-			! class_exists( 'WooCommerce' ) ||
-			(int) addonify_floating_cart_get_option( 'enable_floating_cart' ) === 0
-		) {
+		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart' ) === 0 ) {
 			return;
 		}
 
@@ -77,6 +74,10 @@ class Addonify_Floating_Cart_Public {
 	 * Register ajax actions.
 	 */
 	public function register_ajax_actions() {
+
+		if ( is_cart() || is_checkout() ) {
+			return;
+		}
 
 		add_action( 'wp_ajax_addonify_floating_cart_add_to_cart', array( $this, 'add_to_cart' ) );
 		add_action( 'wp_ajax_nopriv_addonify_floating_cart_add_to_cart', array( $this, 'add_to_cart' ) );
@@ -114,23 +115,7 @@ class Addonify_Floating_Cart_Public {
 	 */
 	public function enqueue_styles() {
 
-		/**
-		* Load in WooCommerce Cart page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_cart() ) {
-
-			return;
-		}
-
-		/**
-		* Load in WooCommerce Checkout page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_checkout() ) {
-
+		if ( is_cart() || is_checkout() ) {
 			return;
 		}
 
@@ -163,23 +148,7 @@ class Addonify_Floating_Cart_Public {
 	 */
 	public function enqueue_scripts() {
 
-		/**
-		* Load in WooCommerce Cart page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_cart() ) {
-
-			return;
-		}
-
-		/**
-		* Load in WooCommerce Checkout page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_checkout() ) {
-
+		if ( is_cart() || is_checkout() ) {
 			return;
 		}
 
@@ -248,26 +217,6 @@ class Addonify_Floating_Cart_Public {
 	 * @since    1.0.0
 	 */
 	public function footer_content() {
-
-		/**
-		* Load in WooCommerce Cart page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_cart() ) {
-
-			return;
-		}
-
-		/**
-		* Load in WooCommerce Checkout page conditionally.
-		*
-		* @since 1.2.0
-		*/
-		if ( (int) addonify_floating_cart_get_option( 'enable_floating_cart_on_cart_page' ) === 0 && is_checkout() ) {
-
-			return;
-		}
 
 		WC()->cart->calculate_totals();
 		WC()->cart->maybe_set_cart_cookies();


### PR DESCRIPTION
…moved options to enable floating cart on cart and checkout pages

- Fix: Plugin setting page link in plugins listing page is displayed before `Deactivate` link.
- Improvement: Used `plugins_loaded`hook to run the plugin.