### PR TITLE
Fixed: Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: cart, floating cart, side cart, mini cart, woocommerce cart
 Requires at least: 6.0.0
 Requires PHP: 7.4
 Tested up to: 6.8
-Stable tag: 1.2.15
+Stable tag: 1.2.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -130,6 +130,11 @@ For more information on shortcode, follow the [documentation](https://docs.addon
 
 
 == Changelog ==
+
+= 1.2.16 - 27 December, 2025 =
+
+- Fixed: Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook.
+- Tested: Up to WordPress version 6.9
 
 = 1.2.15 - 20 April, 2025 =
 

--- a/addonify-floating-cart.php
+++ b/addonify-floating-cart.php
@@ -13,7 +13,7 @@
  * Version:           1.2.15
  * Requires at least: 6.0.0
  * Requires PHP:      7.4
- * Tested up to:      6.8
+ * Tested up to:      6.9
  * Author:            Addonify
  * Author URI:        https://addonify.com/
  * License:           GPLv2 or later
@@ -33,7 +33,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'ADDONIFY_FLOATING_CART_VERSION', '1.2.15' );
+define( 'ADDONIFY_FLOATING_CART_VERSION', '1.2.16' );
 define( 'ADDONIFY_FLOATING_CART_BASENAME', plugin_basename( __FILE__ ) );
 define( 'ADDONIFY_FLOATING_CART_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ADDONIFY_FLOATING_CART_DB_INITIALS', 'addonify_fc_' );

--- a/includes/udp/class-udp-agent.php
+++ b/includes/udp/class-udp-agent.php
@@ -172,6 +172,12 @@ class Udp_Agent {
 	 * @since    1.0.0
 	 */
 	private function process_user_tracking_choice() {
+		// Check if the user is logged in and has the capability to manage options.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			// Redirect to home page.
+			wp_safe_redirect( home_url() );
+			exit;
+		}
 
 		$users_choice = isset( $_GET['udp-agent-allow-access'] ) ? sanitize_text_field( wp_unslash( $_GET['udp-agent-allow-access'] ) ) : ''; //phpcs:ignore
 


### PR DESCRIPTION
- Fixed: Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook.
- Tested: Up to WordPress version 6.9